### PR TITLE
docs: add SentinelByte footer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for what a PR needs to pass before it mer
 ## License
 
 GPL-3.0-or-later — see [LICENSE](LICENSE).
+
+*SentinelByte, 2026*


### PR DESCRIPTION
## Summary
- Adds a small "*SentinelByte, 2026*" footer line under the License section of the README.

## Test plan
- Docs-only change, no functional impact.